### PR TITLE
fix: Remove fields that's not needed due to import from astrocommunity from venv-selector

### DIFF
--- a/lua/plugins/venv-selector.lua
+++ b/lua/plugins/venv-selector.lua
@@ -1,6 +1,5 @@
 return {
   "linux-cultist/venv-selector.nvim",
-  dependencies = { "neovim/nvim-lspconfig", "nvim-telescope/telescope.nvim", "mfussenegger/nvim-dap-python" },
   opts = {
     -- Your options go here
     name = { "venv", ".venv" },
@@ -10,7 +9,6 @@ return {
     -- search = true,
     -- auto_refresh = false
   },
-  event = "VeryLazy", -- Optional: needed only if you want to type `:VenvSelect` without a keymapping
   -- keys = {
   --   -- Keymap to open VenvSelector to pick a venv.
   --   { "<leader>vs", "<cmd>VenvSelect<cr>" },


### PR DESCRIPTION
This should shave off some time from your initial load